### PR TITLE
remove gosimple tool

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -237,7 +237,6 @@ artifacts/logs/lint: vendor $(_SRC) $(REQ) | $(MISSPELL) $(GOMETALINTER) $(USE)
 		--enable=vetshadow \
 		--enable=ineffassign \
 		--enable=deadcode \
-		--enable=gosimple \
 		--enable=gofmt \
 		./src/... | tee -a "$@"
 


### PR DESCRIPTION
This PR is to remove gosimple tool from the first pass of gometalinter in
golang Makefile. This tool is removed as it is no longer available on github.com.